### PR TITLE
remove <ring_size> help/error message from sendsdctoanon. credit to code/kewde for discovery

### DIFF
--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -2315,7 +2315,6 @@ Value sendsdctoanon(const Array& params, bool fHelp)
         throw runtime_error(
             "sendsdctoanon <stealth_address> <amount> [narration] [comment] [comment-to]\n"
             "<amount> is a real and is rounded to the nearest 0.000001"
-            "<ring_size> is a number of outputs of the same amount to include in the signature"
             + HelpRequiringPassphrase());
 
     if (pwalletMain->IsLocked())

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -2314,7 +2314,7 @@ Value sendsdctoanon(const Array& params, bool fHelp)
     if (fHelp || params.size() < 2 || params.size() > 5)
         throw runtime_error(
             "sendsdctoanon <stealth_address> <amount> [narration] [comment] [comment-to]\n"
-            "<amount> is a real and is rounded to the nearest 0.000001"
+            "<amount> is a real number and is rounded to the nearest 0.000001"
             + HelpRequiringPassphrase());
 
     if (pwalletMain->IsLocked())
@@ -2356,7 +2356,7 @@ Value sendanontoanon(const Array& params, bool fHelp)
     if (fHelp || params.size() < 3 || params.size() > 6)
         throw runtime_error(
             "sendanontoanon <stealth_address> <amount> <ring_size> [narration] [comment] [comment-to]\n"
-            "<amount> is a real and is rounded to the nearest 0.000001"
+            "<amount> is a real number and is rounded to the nearest 0.000001\n"
             "<ring_size> is a number of outputs of the same amount to include in the signature"
             + HelpRequiringPassphrase());
 
@@ -2406,7 +2406,8 @@ Value sendanontosdc(const Array& params, bool fHelp)
     if (fHelp || params.size() < 3 || params.size() > 6)
         throw runtime_error(
             "sendanontosdc <stealth_address> <amount> <ring_size> [narration] [comment] [comment-to]\n"
-            "<amount> is a real and is rounded to the nearest 0.000001"
+            "<amount> is a real number and is rounded to the nearest 0.000001\n"
+            "<ring_size> is a number of outputs of the same amount to include in the signature"
             + HelpRequiringPassphrase());
 
     if (pwalletMain->IsLocked())
@@ -2455,7 +2456,8 @@ Value estimateanonfee(const Array& params, bool fHelp)
     if (fHelp || params.size() < 2 || params.size() > 3)
         throw runtime_error(
             "estimateanonfee <amount> <ring_size> [narration]\n"
-            "<amount>is a real and is rounded to the nearest 0.000001");
+            "<amount>is a real number and is rounded to the nearest 0.000001\n"
+            "<ring_size> is a number of outputs of the same amount to include in the signature");
 
     int64_t nAmount = AmountFromValue(params[0]);
 


### PR DESCRIPTION
remove <ring_size> help/error message from sendsdctoanon. credit to
code/kewde for discovery

sendsdctoanon does not use ring signatures.