### PR TITLE
SecureMessaging - bug 100%cpu - test fix

### DIFF
--- a/src/makefile.unix
+++ b/src/makefile.unix
@@ -100,7 +100,7 @@ endif
 
 # CXXFLAGS can be specified on the make command line, so we use xCXXFLAGS that only
 # adds some defaults in front. Unfortunately, CXXFLAGS=... $(CXXFLAGS) does not work.
-xCXXFLAGS=-O1 $(EXT_OPTIONS) -pthread -Wall -Wextra -Wno-ignored-qualifiers -Wformat -Wformat-security -Wno-unused-parameter \
+xCXXFLAGS=-O2 $(EXT_OPTIONS) -pthread -Wall -Wextra -Wno-ignored-qualifiers -Wformat -Wformat-security -Wno-unused-parameter \
     $(DEBUGFLAGS) $(DEFS) $(HARDENING) $(CXXFLAGS)
 
 # LDFLAGS can be specified on the make command line, so we use xLDFLAGS that only

--- a/src/makefile.unix
+++ b/src/makefile.unix
@@ -100,7 +100,7 @@ endif
 
 # CXXFLAGS can be specified on the make command line, so we use xCXXFLAGS that only
 # adds some defaults in front. Unfortunately, CXXFLAGS=... $(CXXFLAGS) does not work.
-xCXXFLAGS=-O2 $(EXT_OPTIONS) -pthread -Wall -Wextra -Wno-ignored-qualifiers -Wformat -Wformat-security -Wno-unused-parameter \
+xCXXFLAGS=-O1 $(EXT_OPTIONS) -pthread -Wall -Wextra -Wno-ignored-qualifiers -Wformat -Wformat-security -Wno-unused-parameter \
     $(DEBUGFLAGS) $(DEFS) $(HARDENING) $(CXXFLAGS)
 
 # LDFLAGS can be specified on the make command line, so we use xLDFLAGS that only

--- a/src/obj/.gitignore
+++ b/src/obj/.gitignore
@@ -1,3 +1,2 @@
 *
 !.gitignore
-!zerocoin

--- a/src/qt/shadowbridge.cpp
+++ b/src/qt/shadowbridge.cpp
@@ -911,7 +911,8 @@ bool ShadowBridge::markMessageAsRead(QString key)
 
 QString ShadowBridge::getPubKey(QString address, QString label)
 {
-    if(!label.isEmpty())
+
+    if(!label.isEmpty() && compare(getAddressLabel(address), "") != 0)
         updateAddressLabel(address, label);
 
     return addressModel->atm->pubkeyForAddress(address);;

--- a/src/qt/shadowbridge.cpp
+++ b/src/qt/shadowbridge.cpp
@@ -840,6 +840,13 @@ QString ShadowBridge::getAddressLabel(QString address)
 
 void ShadowBridge::updateAddressLabel(QString address, QString label)
 {
+    QString actualLabel = getAddressLabel(address);
+
+    if(actualLabel.startsWith("group_"))
+        label = "group_" + label;
+    else if(!actualLabel.startsWith("group_") && label.startsWith("group_"))
+        return;
+
     addressModel->atm->setData(addressModel->atm->index(addressModel->atm->lookupAddress(address), addressModel->atm->Label), QVariant(label), Qt::EditRole);
 }
 

--- a/src/smessage.cpp
+++ b/src/smessage.cpp
@@ -1275,7 +1275,7 @@ bool SecureMsgDisable()
         {
             if (!pnode->smsgData.fEnabled)
                 continue;
-            LOCK2(pnode->cs_vSend, pnode->smsgData.cs_smsg_net);
+            LOCK(pnode->smsgData.cs_smsg_net);
             pnode->PushMessage("smsgDisabled");
             pnode->smsgData.fEnabled = false;
         };

--- a/src/smessage.cpp
+++ b/src/smessage.cpp
@@ -166,7 +166,6 @@ void SecMsgBucket::hashBucket()
     if (fDebugSmsg)
         LogPrintf("SecMsgBucket::hashBucket()\n");
 
-    timeChanged = GetTime();
 
     std::set<SecMsgToken>::iterator it;
 
@@ -177,10 +176,20 @@ void SecMsgBucket::hashBucket()
         XXH32_update(state, it->sample, 8);
     };
 
-    hash = XXH32_digest(state);
+    uint32_t hash_new = XXH32_digest(state);
+
+    if(hash != hash_new){
+
+        if(fDebugSmsg)
+            LogPrintf("Bucket hash updated from %u to %u.\n", hash, hash_new);
+
+        hash = hash_new; //use memcpy here? 
+
+        timeChanged = GetTime();
+    }
 
     if (fDebugSmsg)
-        LogPrintf("Hashed %u messages, hash %u\n", setTokens.size(), hash);
+        LogPrintf("Hashed %u messages, hash %u\n", setTokens.size(), hash_new);
 };
 
 
@@ -1309,6 +1318,27 @@ bool SecureMsgReceiveData(CNode* pfrom, std::string strCommand, CDataStream& vRe
         Runs in ThreadMessageHandler2
     */
 
+    /*
+        Commands
+        + smsgInv = 
+            (1) received inventory of other node. 
+                (1.1) sanity checks
+            (2) loop through buckets
+                (2.1) sanity checks
+                (2.2) check if bucket is locked to another node, if so continue but don't match. TODO: handle this properly, add critical section, lock on write. On read: nothing changes = no lock
+                    (2.2.3) If our bucket is not locked to another node then add hash to buffer to be requested..
+            (3) send smsgShow with list of hashes to request.
+
+        + smsgShow =
+        + smsgHave =
+        + smsgWant =
+        + smsgMsg = ??
+        + smsgPing
+        + smsgPong
+        + smsgMatch
+
+    */
+
     if (fDebugSmsg)
         LogPrintf("SecureMsgReceiveData() %s %s.\n", pfrom->addrName.c_str(), strCommand.c_str());
 
@@ -1450,7 +1480,11 @@ bool SecureMsgReceiveData(CNode* pfrom, std::string strCommand, CDataStream& vRe
             memcpy(&vchDataOut[0], &now, 8);
             pfrom->PushMessage("smsgMatch", vchDataOut);
             if (fDebugSmsg)
-                LogPrintf("Sending smsgMatch, %d.\n", now);
+                LogPrintf("Sending smsgMatch, no locked buckets, time= %d.\n", now);
+        } else 
+        if (nLocked >= 1){
+            if (fDebugSmsg)
+                LogPrintf("%u buckets were locked, time= %d.\n", nLocked, now);
         };
 
     } else
@@ -1700,6 +1734,11 @@ bool SecureMsgReceiveData(CNode* pfrom, std::string strCommand, CDataStream& vRe
     } else
     if (strCommand == "smsgMatch")
     {
+        /*
+        Basically all this code has to go.. 
+        For now we can use it to punish nodes running the older version, not that it's really need because the overhead is small.
+        TODO: remove this code.
+        */
         std::vector<uint8_t> vchData;
         vRecv >> vchData;
 
@@ -1722,13 +1761,13 @@ bool SecureMsgReceiveData(CNode* pfrom, std::string strCommand, CDataStream& vRe
                 LogPrintf("Peer match time set to now.\n");
             time = now;
         };
-
+        /*
         {
             LOCK(pfrom->smsgData.cs_smsg_net);
             pfrom->smsgData.lastMatched = time;
-        }
+        }*/
         if (fDebugSmsg)
-            LogPrintf("Peer buckets matched at %d.\n", time);
+            LogPrintf("[BLOCKED] Peer buckets matched in smsgWant at %d.\n", time);
 
     } else
     if (strCommand == "smsgPing")
@@ -1824,9 +1863,10 @@ bool SecureMsgSendData(CNode* pto, bool fSendTrickle)
     };
 
     // -- When nWakeCounter == 0, resend bucket inventory.
+    /*
     if (pto->smsgData.nWakeCounter < 1)
     {
-        pto->smsgData.lastMatched = 0;
+        pto->smsgData.lastMatched = GetTime(); //used to be 0.
         pto->smsgData.nWakeCounter = 10 + GetRandInt(300);  // set to a random time between [10, 300] * SMSG_SEND_DELAY seconds
 
         if (fDebugSmsg)
@@ -1834,6 +1874,15 @@ bool SecureMsgSendData(CNode* pto, bool fSendTrickle)
             "Now %d next wake counter %u\n", pto->addrName.c_str(), now, pto->smsgData.nWakeCounter);
     };
     pto->smsgData.nWakeCounter--;
+    */
+
+    /*Why resend the whole bucket inventory?
+        Seems like a very odd way to handle it.
+        TODO: remove this code.
+
+    */
+
+
 
     {
         LOCK(cs_smsg);
@@ -1848,19 +1897,45 @@ bool SecureMsgSendData(CNode* pto, bool fSendTrickle)
 
             uint32_t nBucketsShown = 0;
             vchData.resize(4);
-
             uint8_t* p = &vchData[4];
+
+
+        /*
+                Get time before loop and after looping through messages set nLastMatched to time before loop.
+                This prevents scenario where:
+                    Loop()  
+                        message = locked and  thus skipped
+                       message become free and nTimeChanged is updated
+                    End loop
+            
+                    nLastMatched = GetTime()
+                    => bucket that became free in loop is now skipped :/
+
+                Scenario 2:
+                    Same as one but time is updated before
+                    
+                        bucket nTimeChanged is updated but not unlocked yet
+                        now = GetTime()
+                        Loop of buckets skips message
+    
+                    But this is nanoseconds, very unlikely.
+
+             */
+
             for (it = smsgBuckets.begin(); it != smsgBuckets.end(); ++it)
             {
                 SecMsgBucket &bkt = it->second;
 
                 uint32_t nMessages = bkt.setTokens.size();
 
-                if (bkt.timeChanged < pto->smsgData.lastMatched     // peer has this bucket
+                if (bkt.timeChanged < pto->smsgData.lastMatched     // peer was last sent all buckets at time of lastMatched. It should have this bucket
                     || nMessages < 1)                               // this bucket is empty
                     continue;
 
                 uint32_t hash = bkt.hash;
+
+                if(fDebugSmsg)
+                    LogPrintf("Preparing bucket with hash %d for transfer to node %u. timeChanged=%d > lastMatched=%d\n", hash, pto->id, bkt.timeChanged, pto->smsgData.lastMatched);
 
                 try { vchData.resize(vchData.size() + 16); } catch (std::exception& e)
                 {
@@ -1888,7 +1963,8 @@ bool SecureMsgSendData(CNode* pto, bool fSendTrickle)
         };
     } // cs_smsg
 
-    pto->smsgData.lastSeen = GetTime();
+    pto->smsgData.lastSeen = now;
+    pto->smsgData.lastMatched = now; //bug fix smsg 3
 
     return true;
 };

--- a/src/smessage.cpp
+++ b/src/smessage.cpp
@@ -650,7 +650,6 @@ void ThreadSecureMsg()
         for (std::vector<std::pair<int64_t, NodeId> >::iterator it(vTimedOutLocks.begin()); it != vTimedOutLocks.end(); it++)
         {
             NodeId nPeerId = it->second;
-            int64_t ignoreUntil = GetTime() + SMSG_TIME_IGNORE;
 
             if (fDebugSmsg)
                 LogPrintf("Lock on bucket %d for peer %d timed out.\n", it->first, nPeerId);
@@ -663,7 +662,8 @@ void ThreadSecureMsg()
                 {
                     if (pnode->id != nPeerId)
                         continue;
-                    LOCK2(pnode->cs_vSend, pnode->smsgData.cs_smsg_net);
+                    LOCK(pnode->smsgData.cs_smsg_net);
+                    int64_t ignoreUntil = GetTime() + SMSG_TIME_IGNORE;
                     pnode->smsgData.ignoreUntil = ignoreUntil;
 
                     // -- alert peer that they are being ignored


### PR DESCRIPTION
I didn't test this bug fix just yet but I'm pretty sure that this was the issue at hand..
Will need someone to run this for long period of time to verify.
@dasource 

--
Deadlock
LOCK(pnode->cs_vSend) -> PushMessage(..., pnode) -> BeginMessage(...) -> ENTER_CRITICAL_SECTION(cs_vSend)

https://github.com/shadowproject/shadow/blob/master/src/net.h#L531

ENTER_CRITICAL_SECTION is defined by MSDN as

> Waits for ownership of the specified critical section object. The function returns when the calling thread is granted ownership.


I looked through the other code and found no instance where cs_vSend is locked before PushMessage. Instances verifying my suspicion:
https://github.com/shadowproject/shadow/blob/f3fa333f837768823afe16c0347272b5cb8d6c2a/src/main.cpp#L341