### PR TITLE
Add the packaging metadata to build the shadow snap

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -14,7 +14,7 @@ confinement: strict
 
 apps:
   shadow:
-    command: desktop-launch $SNAP/usr/bin/local/umbra
+    command: desktop-launch $SNAP/usr/local/bin/umbra
     plugs: [network, network-bind, unity7]
 
 parts:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -14,8 +14,8 @@ confinement: strict
 
 apps:
   shadow:
-    command: desktop-launch shadow
-    plugs: [network, unity7]
+    command: desktop-launch $SNAP/usr/bin/local/umbra
+    plugs: [network, network-bind, unity7]
 
 parts:
   shadow:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,39 @@
+name: shadow
+version: master
+summary: decentralized peer-to-peer platform
+description: |
+  The Shadow Project is a decentralized peer-to-peer platform, created under an
+  open source license, featuring a built-in cryptocurrency, end-to-end
+  encrypted messaging and decentralized marketplace. The decentralized network
+  aims to provide anonymity and privacy for everyone through a simple
+  user-friendly interface by taking care of all the advanced cryptography in
+  the background.
+
+grade: devel
+confinement: strict
+
+apps:
+  shadow:
+    command: desktop-launch shadow
+    plugs: [network, unity7]
+
+parts:
+  shadow:
+    source: .
+    plugin: qmake
+    qt-version: qt5
+    build-packages:
+      - build-essential
+      - qt5-default
+      - qtbase5-dev-tools
+      - qttools5-dev-tools
+      - libboost-dev
+      - libboost-filesystem-dev
+      - libboost-program-options-dev
+      - libboost-system-dev
+      - libboost-thread-dev
+      - libdb++-dev
+      - libminiupnpc-dev
+      - libqt5webkit5-dev
+      - libssl-dev
+    after: [desktop-qt5]


### PR DESCRIPTION
This is a package for the secure installation of apps that works in most Linux distributions.
Landing it upstream will enable builds for adventurous users.
