### PR TITLE
Fixed help and datadir parameters.

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -560,7 +560,7 @@ bool AppInit2(boost::thread_group& threadGroup)
     if (strWalletFileName != fs::basename(strWalletFileName) + fs::extension(strWalletFileName))
         return InitError(strprintf(_("Wallet %s resides outside data directory %s."), strWalletFileName.c_str(), strDataDir.c_str()));
 
-    // Make sure only a single Bitcoin process is using the data directory.
+    // Make sure only a single Shadow process is using the data directory.
     fs::path pathLockFile = GetDataDir() / ".lock";
     FILE* file = fopen(pathLockFile.string().c_str(), "a"); // empty lock file; created if it doesn't exist.
     if (file)

--- a/src/qt/shadow.cpp
+++ b/src/qt/shadow.cpp
@@ -124,6 +124,10 @@ int main(int argc, char *argv[])
 #endif
 
     Q_INIT_RESOURCE(shadow);
+
+    // Command-line options take precedence:
+    ParseParameters(argc, argv);
+
     QApplication app(argc, argv);
     
     // Do this early as we don't want to bother initializing if we are just calling IPC
@@ -134,9 +138,6 @@ int main(int argc, char *argv[])
 
     // Install global event filter that makes sure that long tooltips can be word-wrapped
     app.installEventFilter(new GUIUtil::ToolTipToRichTextFilter(TOOLTIP_WRAP_THRESHOLD, &app));
-
-    // Command-line options take precedence:
-    ParseParameters(argc, argv);
 
     // ... then shadowcoin.conf:
     if (!boost::filesystem::is_directory(GetDataDir(false)))
@@ -198,7 +199,8 @@ int main(int argc, char *argv[])
 
     // Show help message immediately after parsing command-line options (for "-lang") and setting locale,
     // but before showing splash screen.
-    if (mapArgs.count("-?") || mapArgs.count("--help"))
+
+    if (mapArgs.count("-?") || mapArgs.count("-h") || mapArgs.count("-help"))
     {
         GUIUtil::HelpMessageBox help;
         help.showOrPrint();

--- a/src/shadowcoind.cpp
+++ b/src/shadowcoind.cpp
@@ -143,7 +143,7 @@ void WaitForShutdown(boost::thread_group* threadGroup)
 bool AppInit(int argc, char* argv[])
 {
     boost::thread_group threadGroup;
-    
+
     bool fRet = false;
     try
     {
@@ -157,12 +157,12 @@ bool AppInit(int argc, char* argv[])
             fprintf(stderr, "Error: Specified directory does not exist\n");
             Shutdown();
         };
-        
+
         ReadConfigFile(mapArgs, mapMultiArgs);
-        
-        if (mapArgs.count("-?") || mapArgs.count("--help"))
+
+        if (mapArgs.count("-?") || mapArgs.count("-h") || mapArgs.count("-help"))
         {
-            // First part of help message is specific to bitcoind / RPC client
+            // First part of help message is specific to shadowcoind / RPC client
             std::string strUsage = _("ShadowCoin version") + " " + FormatFullVersion() + "\n\n" +
                 _("Usage:") + "\n" +
                   "  shadowcoind [options]                     " + "\n" +

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1125,16 +1125,16 @@ boost::filesystem::path GetConfigFile()
 void ReadConfigFile(map<string, string>& mapSettingsRet,
                     map<string, vector<string> >& mapMultiSettingsRet)
 {
-   boost::filesystem::ifstream streamConfig(GetConfigFile());
+    boost::filesystem::ifstream streamConfig(GetConfigFile());
     if (!streamConfig.good())
-        return; // No bitcoin.conf file is OK
+        return; // No shadowcoin.conf file is OK
 
     set<string> setOptions;
     setOptions.insert("*");
 
     for (boost::program_options::detail::config_file_iterator it(streamConfig, setOptions), end; it != end; ++it)
     {
-        // Don't overwrite existing settings so command line settings override bitcoin.conf
+        // Don't overwrite existing settings so command line settings override shadowcoin.conf
         string strKey = string("-") + it->string_key;
         if (mapSettingsRet.count(strKey) == 0)
         {


### PR DESCRIPTION
Double dashes are collapsed --help -> -help
Added -h

GetDataDir was run before mapArgs was filled, caching the default path.